### PR TITLE
Decoupling Of Vent And VentMap.

### DIFF
--- a/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/VentMap.java
+++ b/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/VentMap.java
@@ -12,12 +12,6 @@ import org.jetbrains.annotations.NotNull;
 
 //FIXME
 public abstract class VentMap {
-	//TODO
-	final Map<Class<? extends Vent>, Set<Vent.Subscription<?>>> subscriptionMap = new HashMap<>();
-
-	final LinkedList<Vent.Subscription<?>> subscriptions = new LinkedList<>();
-
-	final LinkedList<VentListener> listeners = new LinkedList<>();
 
 	/**
 	 * Unsubscribe from an event by providing the key of the desired subscription if found.
@@ -131,4 +125,7 @@ public abstract class VentMap {
 	 */
 	public abstract void chain(Vent.Link link);
 
+	public abstract List<Vent.Subscription<?>> getSubscriptions();
+
+	public abstract List<VentListener> getListeners();
 }

--- a/labyrinth-plugin/src/main/java/com/github/sanctum/labyrinth/event/custom/VentMapImpl.java
+++ b/labyrinth-plugin/src/main/java/com/github/sanctum/labyrinth/event/custom/VentMapImpl.java
@@ -3,7 +3,11 @@ package com.github.sanctum.labyrinth.event.custom;
 import com.github.sanctum.labyrinth.LabyrinthProvider;
 import com.github.sanctum.labyrinth.task.Schedule;
 
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -12,6 +16,12 @@ import org.jetbrains.annotations.NotNull;
 
 //FIXME
 public final class VentMapImpl extends VentMap {
+
+	final LinkedList<Vent.Subscription<?>> subscriptions = new LinkedList<>();
+
+	final LinkedList<VentListener> listeners = new LinkedList<>();
+
+	final Map<Class<? extends Vent>, Set<Vent.Subscription<?>>> subscriptionMap = new HashMap<>();
 
 	@Override //TODO
 	public <T extends Vent> void unsubscribe(@NotNull Class<T> eventType, @NotNull String key) {
@@ -142,5 +152,15 @@ public final class VentMapImpl extends VentMap {
 			subscriptions.add(parent);
 		}
 
+	}
+
+	@Override
+	public LinkedList<Vent.Subscription<?>> getSubscriptions() {
+		return subscriptions;
+	}
+
+	@Override
+	public LinkedList<VentListener> getListeners() {
+		return listeners;
 	}
 }


### PR DESCRIPTION
Now fields have getters and use them to access the saved listeners and subscriptions.
Should be save to merge. If there are any problems, then they are easily solvable by using the new getters instead of direct access