### PR TITLE
Addition of @Extend

### DIFF
--- a/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/data/ServiceType.java
+++ b/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/data/ServiceType.java
@@ -1,6 +1,8 @@
 package com.github.sanctum.labyrinth.data;
 
 import com.github.sanctum.labyrinth.api.Service;
+
+import java.util.Arrays;
 import java.util.function.Supplier;
 
 public class ServiceType<T extends Service> {
@@ -8,9 +10,12 @@ public class ServiceType<T extends Service> {
 	final Supplier<T> supplier;
 	Class<T> c;
 
+	@SuppressWarnings("unchecked")
 	public ServiceType(Supplier<T> supplier) {
 		this.supplier = supplier;
-		c = (Class<T>) supplier.get().getClass();
+		c = (Class<T>) Arrays.stream(supplier.getClass().getMethods())
+				.filter(m -> m.getName().equals("get") && m.getParameterTypes().length == 0)
+				.findFirst().orElseThrow((IllegalArgumentException::new)).getReturnType();
 	}
 
 	public Class<T> getType() {

--- a/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/Extend.java
+++ b/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/Extend.java
@@ -1,0 +1,30 @@
+package com.github.sanctum.labyrinth.event.custom;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark consumer methods for results of event handling.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Extend {
+
+	/**
+	 * Sets the key for this annotation to be recognised by other Extend annotations
+	 *
+	 * @return the key of the marked method
+	 */
+	String identifier();
+
+	/**
+	 * Sets the target methods of this extension. If any of these targets gets called, the result will be passed
+	 * to the annotated method.
+	 *
+	 * @return the keys of the parameter-supplying methods
+	 */
+	String[] targets();
+
+}

--- a/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/Extend.java
+++ b/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/Extend.java
@@ -13,18 +13,19 @@ import java.lang.annotation.Target;
 public @interface Extend {
 
 	/**
-	 * Sets the key for this annotation to be recognised by other Extend annotations
+	 * Sets the key for this annotation.
+	 * The key will be used to pass return values from methods with this key in their result processor list.
+	 * Works for other {@link Extend} annotated methods and for {@link Subscribe}
 	 *
 	 * @return the key of the marked method
 	 */
 	String identifier();
 
 	/**
-	 * Sets the target methods of this extension. If any of these targets gets called, the result will be passed
-	 * to the annotated method.
+	 * Sets the keys of methods where the results of this method will be passed to.
 	 *
-	 * @return the keys of the parameter-supplying methods
+	 * @return the keys of the return-result-consuming methods
 	 */
-	String[] targets();
+	String[] resultProcessors() default {};
 
 }

--- a/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/Subscribe.java
+++ b/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/Subscribe.java
@@ -13,4 +13,5 @@ public @interface Subscribe {
 
 	boolean ignore() default false;
 
+	String[] resultProcessors() default {};
 }

--- a/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/VentListener.java
+++ b/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/VentListener.java
@@ -3,12 +3,17 @@ package com.github.sanctum.labyrinth.event.custom;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.bukkit.Bukkit;
@@ -21,7 +26,8 @@ import com.github.sanctum.labyrinth.data.service.AnnotationDiscovery;
 /**
  * Core class for internal listener implementation
  * Wraps around any objects, detects methods annotated with {@link Subscribe} and creates SubscriberCalls with it.
- * Always has s string as key, which may be "null";
+ * Also, it recognises methods annotated with {@link Extend} and adds them to the method linking pool
+ * Always has s string as key, which may be "null", when not specified by {@link LabeledAs};
  */
 
 public class VentListener {
@@ -46,6 +52,8 @@ public class VentListener {
 	 */
 	private final Map<Class<? extends Vent>, Map<Vent.Priority, Set<SubscriberCall<?>>>> eventMap = new HashMap<>();
 
+	private final List<VentExtender<?>> extenders = new LinkedList<>();
+
 	/**
 	 * Creates an VentListener out of the passed listener object and with the plugin as callback for communication
 	 *
@@ -57,8 +65,8 @@ public class VentListener {
 		this.host = host;
 		this.label = readKey();
 		buildEventHandlers();
+		buildExtensors();
 	}
-
 
 	/**
 	 * Tries to detect a {@link LabeledAs} annotation on this class which contains the key.
@@ -78,14 +86,47 @@ public class VentListener {
 		discovery.filter(m -> m.getParameters().length == 1 && Vent.class.isAssignableFrom(m.getParameters()[0].getType())
 							  && m.isAnnotationPresent(Subscribe.class) && Modifier.isPublic(m.getModifiers()));
 		discovery.methods().forEach(m -> {
+					Optional<Subscribe> subscribe = discovery.read(m).stream().findAny();
 					@SuppressWarnings("unchecked")
 					Class<? extends Vent> mClass = (Class<? extends Vent>) m.getParameters()[0].getType();
-					Vent.Priority priority = discovery.read(m).stream().findAny().map(Subscribe::priority)
-							.orElse(Vent.Priority.MEDIUM);
-					registerSubscription(m, mClass, priority);
+					if (subscribe.isPresent()) {
+						registerSubscription(m, mClass, subscribe.get());
+					} else {
+						Bukkit.getLogger().severe("Error registering " + m.getDeclaringClass() + "#" +
+												  m.getName());
+					}
 				}
 
 		);
+	}
+
+	private void buildExtensors() {
+		AnnotationDiscovery<Extend, ?> discovery = AnnotationDiscovery.of(Extend.class, listener);
+		discovery.filter(m -> m.getParameters().length == 1 && m.isAnnotationPresent(Extend.class)
+							  && Modifier.isPublic(m.getModifiers()));
+		discovery.methods().forEach(m -> {
+			Optional<Extend> extend = discovery.read(m).stream().findAny();
+			if (extend.isPresent()) {
+				Class<?> parameterClass = m.getParameters()[0].getType();
+				registerExtender(m, parameterClass, extend.get());
+			} else {
+				Bukkit.getLogger().severe("Error registering " + m.getDeclaringClass() + "#" + m.getName());
+			}
+		});
+	}
+
+	private <T> void registerExtender(final Method m, final Class<T> parameterClass, Extend extend) {
+		VentExtender<?> extender;
+		String key = extend.identifier();
+		if (m.getReturnType().equals(Void.TYPE)) {
+			extender = new VentExtender<>(parameterClass, t -> invokeAsExtender(m, Object.class, t),
+					key, this);
+		} else {
+			extender = new LinkingVentExtender<>(parameterClass, t -> invokeAsExtender(m, m.getReturnType(), t),
+					key, this, extend.resultProcessors());
+		}
+		extenders.add(extender);
+		LabyrinthProvider.getInstance().getEventMap().registerExtender(extender);
 	}
 
 	/**
@@ -93,27 +134,54 @@ public class VentListener {
 	 * The constructed subscription will include exception catching for any errors occurring while using the
 	 * subscriber call and will display an informative message in that case, including the stacktrace.
 	 *
-	 * @param method   the method to use
-	 * @param tClass   the class the method accepts as first and only parameter
-	 * @param priority the priority provided by the methods annotation
-	 * @param <T>      the type parameter of tClass
+	 * @param method    the method to use
+	 * @param tClass    the class the method accepts as first and only parameter
+	 * @param subscribe the annotation containing the conditions of the registration
+	 * @param <T>       the type parameter of tClass
 	 */
-	private <T extends Vent> void registerSubscription(Method method, Class<T> tClass, final Vent.Priority priority) {
-		SubscriberCall<T> call = (t, s) -> {
-			try {
-				method.invoke(listener, t);
-			} catch (IllegalAccessException | InvocationTargetException e) {
-				Bukkit.getLogger().severe("Internal error hindered the " + listener.getClass().getName() + "#"
-										  + method.getName() + " to handle events. Check method accessibility" +
-										  " and parameters");
-			} catch (Exception e) {
-				Bukkit.getLogger().severe("Could not pass event " + tClass.getName() + " to " + host);
-				e.printStackTrace();
-			}
-		};
+	private <T extends Vent> void registerSubscription(Method method, Class<T> tClass, Subscribe subscribe) {
+		SubscriberCall<T> call;
+		if (method.getReturnType().equals(Void.TYPE)) {
+			//register as SubscriberCall lambda
+			call = (t, s) -> invokeAsListener(method, tClass.getName(), Object.class, t);
+		} else {
+			//register as linking object
+			Class<?> resultClass = method.getReturnType();
+			call = new ListenerCall<>(subscribe.resultProcessors(),
+					t -> invokeAsListener(method, tClass.getName(), resultClass, t));
+		}
 		eventMap.computeIfAbsent(tClass, c -> new HashMap<>())
-				.computeIfAbsent(priority, p -> new HashSet<>())
+				.computeIfAbsent(subscribe.priority(), p -> new HashSet<>())
 				.add(call);
+	}
+
+	private <T> CallInfo<T> invokeAsListener(Method method, String eventName, Class<T> resultClass, Object... params) {
+		String reflectionError = "Internal error hindered the " + listener.getClass().getName() + "#"
+								 + method.getName() + " to handle events. Check method accessibility" +
+								 " and parameters!";
+		String callError = "Could not pass event " + eventName + " to " + host;
+		return invoke(method, reflectionError, callError, resultClass, params);
+	}
+
+	private <T> CallInfo<T> invokeAsExtender(Method method, Class<T> resultClass, Object... params) {
+		String passed = "passed elements " + Arrays.toString(params);
+		String reflectionError = "Internal error hindered the " + listener.getClass().getName() + "#"
+								 + method.getName() + " to further process " + passed +
+								 ". Check method accessibility and parameters!";
+		String callError = "Could not process" + passed + " at " + host;
+		return invoke(method, reflectionError, callError, resultClass, params);
+	}
+
+	private <T> CallInfo<T> invoke(Method method, String refError, String callError, Class<T> retC, Object... params) {
+		try {
+			return new CallInfo<>(true, retC.cast(method.invoke(listener, params)));
+		} catch (IllegalAccessException | InvocationTargetException e) {
+			Bukkit.getLogger().severe(refError);
+		} catch (Exception e) {
+			Bukkit.getLogger().severe(callError);
+			e.printStackTrace();
+		}
+		return new CallInfo<>(false, null);
 	}
 
 	/**
@@ -157,7 +225,9 @@ public class VentListener {
 	 * Removes this Listener from event service, so that no more calls will be executed on it.
 	 */
 	public void remove() {
-		LabyrinthProvider.getInstance().getEventMap().unregister(host, getKey(), listener);
+		VentMap map = LabyrinthProvider.getInstance().getEventMap();
+		map.unregister(host, getKey(), listener);
+		extenders.forEach(map::unregisterExtender);
 	}
 
 
@@ -183,4 +253,95 @@ public class VentListener {
 			   ", eventMap=" + eventMap +
 			   '}';
 	}
+
+	public static class ListenerCall<S, T extends Vent> implements SubscriberCall<T> {
+
+		private final String[] extenders;
+
+		private final Function<T, CallInfo<S>> eventHandler;
+
+		public ListenerCall(final String[] extenders, final Function<T, CallInfo<S>> eventHandler) {
+			this.extenders = extenders;
+			this.eventHandler = eventHandler;
+		}
+
+		@Override
+		public void accept(final T event, final Vent.Subscription<T> unused) {
+			CallInfo<S> callInfo = eventHandler.apply(event);
+			if (callInfo.success) {
+				for (String target : extenders)
+					VentExtender.runExtensions(target, callInfo.result);
+			}
+		}
+	}
+
+	static class VentExtender<T> {
+
+		private final Class<T> type;
+
+		private final Consumer<T> extender;
+
+		private final String key;
+
+		private final Object parent;
+
+		VentExtender(final Class<T> type, final Consumer<T> extender, final String key, final Object parent) {
+			this.type = type;
+			this.extender = extender;
+			this.key = key;
+			this.parent = parent;
+		}
+
+		public static void runExtensions(String key, Object toProcess) {
+			LabyrinthProvider.getInstance().getEventMap().getExtenders(key)
+					.filter(e -> e.getType().isAssignableFrom(toProcess.getClass()))
+					.forEach(e -> runFinisher(e, toProcess));
+		}
+
+		private static <E> void runFinisher(VentExtender<E> ventExtender, Object toProcess) {
+			ventExtender.extender.accept(ventExtender.getType().cast(toProcess));
+		}
+
+		public String getKey() {
+			return key;
+		}
+
+		public Object getParent() {
+			return parent;
+		}
+
+		public Class<T> getType() {
+			return type;
+		}
+	}
+
+	static final class LinkingVentExtender<S, T> extends VentExtender<T> {
+
+		LinkingVentExtender(final Class<T> type, Function<T, CallInfo<S>> base, final String key,
+							final Object parent, String[] targets) {
+			super(type, buildExtender(base, targets), key, parent);
+		}
+
+		private static <T, S> Consumer<T> buildExtender(Function<T, CallInfo<S>> base, String[] targets) {
+			return t -> {
+				CallInfo<S> callInfo = base.apply(t);
+				if (callInfo.success) {
+					for (String target : targets) {
+						VentExtender.runExtensions(target, callInfo.result);
+					}
+				}
+			};
+		}
+	}
+
+	static final class CallInfo<T> {
+		private final boolean success;
+		private final T result;
+
+		CallInfo(final boolean success, final T result) {
+			this.success = success;
+			this.result = result;
+		}
+	}
+
 }

--- a/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/VentMap.java
+++ b/labyrinth-common/src/main/java/com/github/sanctum/labyrinth/event/custom/VentMap.java
@@ -1,6 +1,7 @@
 package com.github.sanctum.labyrinth.event.custom;
 
 import com.github.sanctum.labyrinth.api.Service;
+
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -151,4 +152,10 @@ public abstract class VentMap implements Service {
 																				   Vent.Priority priority);
 
 	public abstract List<VentListener> getListeners();
+
+	public abstract void registerExtender(VentListener.VentExtender<?> extender);
+
+	public abstract void unregisterExtender(VentListener.VentExtender<?> extender);
+
+	public abstract Stream<VentListener.VentExtender<?>> getExtenders(String key);
 }


### PR DESCRIPTION
Added a new annotation type compatible with @Subscribe, which will make it possible to catch and handle return values  of listeners. 
The redirections are defined recursively, so that the workflow doesn't stop if you don't want it to stop.
Also, you are able to pass return values to multiple methods with one annotation instead of 10 subsequent calls.