### PR TITLE
Create maven-ci.yml

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -1,0 +1,26 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Maven CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/labyrinth-common/pom.xml
+++ b/labyrinth-common/pom.xml
@@ -16,10 +16,7 @@
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
         </dependency>
-
     </dependencies>
-
 
 </project>

--- a/labyrinth-plugin/pom.xml
+++ b/labyrinth-plugin/pom.xml
@@ -59,6 +59,12 @@
                                         <exclude>examples.yml</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>*:json-simple</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                         </configuration>
@@ -110,7 +116,12 @@
         <dependency>
             <groupId>com.github.the-h-team</groupId>
             <artifactId>templates</artifactId>
-            <version>1.0.0</version>
+            <version>${templates.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/labyrinth-plugin/pom.xml
+++ b/labyrinth-plugin/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>com.github.the-h-team</groupId>
             <artifactId>templates</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <properties>
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <templates.version>1.0.0</templates.version>
     </properties>
 
     <licenses>
@@ -141,8 +142,20 @@
             <dependency>
                 <groupId>com.github.the-h-team</groupId>
                 <artifactId>templates</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>${templates.version}</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.googlecode.json-simple</groupId>
+                <artifactId>json-simple</artifactId>
+                <version>1.1.1</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -182,21 +182,16 @@
 
     <profiles>
         <profile>
-            <!-- GitHub Actions deployment -->
-            <id>deploy</id>
+            <!-- GitHub Actions continuous integration (add source+javadoc) -->
+            <id>ci-build</id>
+            <activation>
+                <property>
+                    <name>CI</name>
+                    <value>true</value>
+                </property>
+            </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                        </configuration>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
@@ -226,6 +221,27 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- GitHub Actions deployment -->
+            <id>deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.8</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <!-- Moved source+javadoc sections -->
+                    <!-- Make sure CI = true or that ci-build profile is active! -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
All this workflow does is run a test build\* any time:
1. We push to master
1. Someone opens a PR that targets master

This workflow is handy because it'll catch build failures immediately--completely independent from our single current workflow (which can instead be triggered only as-needed for deployments).

\* AFAIK the build doesn't go anywhere, doesn't do anything else, but by having Actions do it saves the extra steps of committing and forgetting when we've half-finished code.